### PR TITLE
Perform keydef extraction during indexing. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
 		</dependency>
 		<dependency>
 			<groupId>se.simonsoft</groupId>
+			<artifactId>cms-indexing-keydef</artifactId>
+			<version>0.1.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>se.simonsoft</groupId>
 			<artifactId>cms-backend-svnkit</artifactId>
 			<version>1.2.4</version>
 		</dependency>

--- a/src/main/java/se/repos/indexing/standalone/config/IndexingHandlersModuleXml.java
+++ b/src/main/java/se/repos/indexing/standalone/config/IndexingHandlersModuleXml.java
@@ -7,6 +7,9 @@ import net.sf.saxon.lib.ExtensionFunctionDefinition;
 import net.sf.saxon.s9api.Processor;
 import se.repos.indexing.IndexingItemHandler;
 import se.repos.indexing.fulltext.HandlerFulltext;
+import se.simonsoft.cms.indexing.keydef.HandlerKeydef;
+import se.simonsoft.cms.indexing.keydef.HandlerKeydefExcel;
+import se.simonsoft.cms.indexing.keydef.HandlerKeydefXliff;
 import se.simonsoft.cms.indexing.xml.IndexAdminXml;
 import se.simonsoft.cms.indexing.xml.IndexingHandlersXml;
 import se.simonsoft.cms.indexing.xml.XmlIndexFieldExtraction;
@@ -47,6 +50,8 @@ public class IndexingHandlersModuleXml extends AbstractModule {
 		Multibinder<IndexingItemHandler> handlers = Multibinder.newSetBinder(binder(), IndexingItemHandler.class);
 		IndexingHandlersXml.configureFirst(handlers);
 		handlers.addBinding().to(HandlerFulltext.class);
+		handlers.addBinding().to(HandlerKeydefXliff.class);
+		handlers.addBinding().to(HandlerKeydefExcel.class);
 		IndexingHandlersXml.configureLast(handlers);
 		
 		// XML field extraction


### PR DESCRIPTION
Requires the new module cms-indexing-keydef.