### PR TITLE
Ensure repositories are indexed in lexical order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
 							<Repos-Build-Tag>${BUILD_TAG}</Repos-Build-Tag>
 							<Repos-Build-Name>${JOB_NAME}</Repos-Build-Name>
 							<Repos-Build-Revision>${SVN_REVISION}</Repos-Build-Revision>
+							<Repos-Build-Commit>${GIT_COMMIT}</Repos-Build-Commit>
 							<Repos-Build-Number>${BUILD_NUMBER}</Repos-Build-Number>
 						</manifestEntries>
 					</archive>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>se.repos</groupId>
 		<artifactId>maven-parent</artifactId>
-		<version>2.6</version>
+		<version>2.7</version>
 		<relativePath/>
 	</parent>
 	

--- a/src/main/java/se/repos/indexing/standalone/IndexingDaemon.java
+++ b/src/main/java/se/repos/indexing/standalone/IndexingDaemon.java
@@ -9,10 +9,10 @@ import java.nio.channels.NonWritableChannelException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +46,7 @@ public class IndexingDaemon implements Runnable {
 	protected Injector global;
 	
 	protected Map<File, CmsRepository> known = new HashMap<File, CmsRepository>();
-	protected Map<CmsRepository, ReposIndexing> loaded = new LinkedHashMap<CmsRepository, ReposIndexing>();
+	protected Map<CmsRepository, ReposIndexing> loaded = new TreeMap<CmsRepository, ReposIndexing>(new CmsRepositoryComparator());
 	protected Map<CmsRepository, RepoRevision> previous = new HashMap<CmsRepository, RepoRevision>();
 	protected Map<CmsRepository, CmsContentsReader> contentsReaders = new HashMap<CmsRepository, CmsContentsReader>();
 	protected List<CmsRepository> reposToRemove = null;
@@ -117,6 +117,12 @@ public class IndexingDaemon implements Runnable {
 	public long getWait() {
 		return this.wait;
 	}
+	
+	// For testing
+	Set<CmsRepository> getRepositoriesLoaded() {
+		return this.loaded.keySet();
+	}
+	
 
 	protected void addRepository(File path, String url) {
 		if (known.containsKey(path)) {
@@ -326,6 +332,17 @@ public class IndexingDaemon implements Runnable {
 			return true;
 		}
 		
+	}
+	
+	static class CmsRepositoryComparator implements java.util.Comparator<CmsRepository> {
+		@Override
+		public int compare(CmsRepository o1, CmsRepository o2) {
+			if (o1 == null) throw new IllegalArgumentException("CmsRepository can not be null");
+			if (o2 == null) throw new IllegalArgumentException("CmsRepository can not be null");
+			if (o1.getName() == null) throw new IllegalArgumentException("CmsRepository must have name " + o1);
+			if (o2.getName() == null) throw new IllegalArgumentException("CmsRepository must have name " + o2);
+			return o1.getName().compareTo(o2.getName());
+		}
 	}
 	
 }

--- a/src/main/java/se/repos/indexing/standalone/IndexingDaemon.java
+++ b/src/main/java/se/repos/indexing/standalone/IndexingDaemon.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.slf4j.Logger;
@@ -46,7 +47,7 @@ public class IndexingDaemon implements Runnable {
 	protected Injector global;
 	
 	protected Map<File, CmsRepository> known = new HashMap<File, CmsRepository>();
-	protected Map<CmsRepository, ReposIndexing> loaded = new TreeMap<CmsRepository, ReposIndexing>(new CmsRepositoryComparator());
+	protected SortedMap<CmsRepository, ReposIndexing> loaded = new TreeMap<CmsRepository, ReposIndexing>(new CmsRepositoryComparator());
 	protected Map<CmsRepository, RepoRevision> previous = new HashMap<CmsRepository, RepoRevision>();
 	protected Map<CmsRepository, CmsContentsReader> contentsReaders = new HashMap<CmsRepository, CmsContentsReader>();
 	protected List<CmsRepository> reposToRemove = null;

--- a/src/test/java/se/repos/indexing/standalone/IndexingDaemonTest.java
+++ b/src/test/java/se/repos/indexing/standalone/IndexingDaemonTest.java
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2004-2012 Repos Mjukvara AB
+ */
 package se.repos.indexing.standalone;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/se/repos/indexing/standalone/IndexingDaemonTest.java
+++ b/src/test/java/se/repos/indexing/standalone/IndexingDaemonTest.java
@@ -1,0 +1,51 @@
+package se.repos.indexing.standalone;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.solr.client.solrj.SolrServer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import se.repos.indexing.standalone.config.SolrCoreProvider;
+import se.simonsoft.cms.item.CmsRepository;
+
+public class IndexingDaemonTest {
+
+	SolrCoreProvider solrCoreProvider;
+	SolrServer solrServer;
+	
+	
+	@Before
+	public void initMocks() {
+		solrServer = Mockito.mock(SolrServer.class);
+		solrCoreProvider = Mockito.mock(SolrCoreProvider.class);
+		when(solrCoreProvider.getSolrCore(Mockito.anyString())).thenReturn(solrServer);
+	}
+	
+	@Test
+	public void testRepositoryOrder() {
+		
+		List<String> repositories = Arrays.asList("repo1", "repo2", "demo1");
+		
+		IndexingDaemon d = new IndexingDaemon(new File("/tmp"), "http://localhost/svn/", repositories, this.solrCoreProvider);
+		
+		Set<CmsRepository> set = d.getRepositoriesLoaded();
+		
+		assertEquals(3, set.size());
+		//assertEquals("java.util.TreeMap$KeySet", set.getClass().getName());
+		
+		Iterator<CmsRepository> it = set.iterator();
+		assertEquals("http://localhost/svn/demo1", it.next().toString());
+		assertEquals("http://localhost/svn/repo1", it.next().toString());
+		assertEquals("http://localhost/svn/repo2", it.next().toString());
+	}
+
+}


### PR DESCRIPTION
 - Simplifies estimation of progress in multi-repo setups.
 - Simplifies detection of indexing completeness, without reading the log.